### PR TITLE
0.9.0

### DIFF
--- a/scratch.ps1
+++ b/scratch.ps1
@@ -83,3 +83,20 @@ process {
 end {
 
 }
+
+
+
+$cmd =  @'
+pktmon start --capture --flags 0x010 --comp 119 119 13 --log-mode real-time | & { process {
+         switch -Regex ($PSItem) {
+             # ping4 (ICMP Echo)
+             "(?:ICMP echo)" { Write-Host "$PSItem" }
+             # ping6 (ICMPv6 Echo)
+             "(?:ICMP6, echo)" { [System.Console]::WriteLine("$PSItem") }
+             # write hidden lines to Verbose for funzies
+             default {Write-Verbose "$PSItem"}
+         }
+     }}
+'@
+
+Invoke-Expression $cmd


### PR DESCRIPTION
Fixes:

- Removed Port from non-TCP/UDP filters. pktmon allows a port to be added to protocols without ports, and that breaks output.
- Simplified and sped-up interface detection.
- Moved filters to a switch that loops through PSBoundParameters.
- Code cleanup.

Additions:

- NDP - Network Discovery Protocol which outputs ICMPv6 neighbor and router solicitation/advertisement packets.
- ARP - Address Resolution Protocol which outputs ARP request and reply packets.